### PR TITLE
(build) Fixed regex used in appveyor.yml files

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,8 +33,8 @@ branches:
   only:
     - develop
     - master
-    - /release/.*/
-    - /hotfix/.*/
+    - /release\/.*/
+    - /hotfix\/.*/
 
 #---------------------------------#
 #  Build Cache                    #
@@ -47,4 +47,4 @@ cache:
 #---------------------------------#
 skip_commits:
   # Regex for matching commit message
-  message: /(doc).*/
+  message: /\(doc\).*/


### PR DESCRIPTION
The regex for branch whitelist and for skipping
documentation commits is not correct regular expressions.
This pull request makes the necessary changes to fix that.

NOTE: The regex used for the branches could also be re-used by travis (copied over) if wanted.

NOTE 2: I was lazy now :smile: 